### PR TITLE
use pre-compiled binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,24 +8,22 @@ jobs:
       if: success()
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.x
+        go-version: 1.15.x
     - name: Checkout code
       uses: actions/checkout@v1
     - name: Integration test
       run: |
-        # perform an integration test with original gcov2lcov integration 
+        # perform an integration test with original gcov2lcov integration
         # test data, which is available in the testdata/ directory.
         docker build -t gcov2lcov-action .
-
         # create bare-bones go project to run the action on
         mkdir -p gcov2lcov/.git
         echo -e '[remote "origin"]\nurl = git@github.com:jandelgado/gcov2lcov\n' > gcov2lcov/.git/config
         echo -e "package main\n" > gcov2lcov/main.go
-        echo -e "module github.com/jandelgado/gcov2lcov\ngo 1.12\n" > gcov2lcov/go.mod
+        echo -e "module github.com/jandelgado/gcov2lcov\ngo 1.15\n" > gcov2lcov/go.mod
         cp testdata/coverage.out gcov2lcov/
-
         docker run -e "GITHUB_WORKSPACE=/test" \
                    -e "INPUT_INFILE=coverage.out" \
                    -e "INPUT_OUTFILE=coverage.lcov" \
                    -i --rm -v "$PWD/gcov2lcov:/test" gcov2lcov-action
-        diff testdata/coverage_expected.lcov gcov2lcov/coverage.lcov
+        diff -y testdata/coverage_expected.lcov gcov2lcov/coverage.lcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 # note: gcov2lcov also needs a running go executable in the container, so we
 # keep this as the base 
-FROM golang:1.13-alpine 
+FROM golang:1.15-alpine
+
+ARG VERSION=v1.0.4
 
 LABEL MAINTAINER="Jan Delgado <jdelagdo@gmx.net>"
 LABEL "com.github.actions.description"="convert golang coverager to lcov format"
 LABEL "com.github.actions.name"="gcov2lcov-action"
 LABEL "com.github.actions.color"="blue"
 
-WORKDIR /go/src/app
-ADD . /go/src/app
+WORKDIR /app
+ADD . /app
 
-RUN GO111MODULE=on go get -u github.com/jandelgado/gcov2lcov@v1.0.3
+ENV GOROOT=/usr/local/go
+RUN wget https://github.com/jandelgado/gcov2lcov/releases/download/${VERSION}/gcov2lcov-linux-amd64.tar.gz -q -O - |\
+      tar xvzf - --strip 1\
+   && chmod 755 gcov2lcov-linux-amd64 
 
 COPY entrypoint.sh /
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 set -eu
 
-unset GOROOT
 unset GOPATH
 
 cd $GITHUB_WORKSPACE
-/go/bin/gcov2lcov -infile "$INPUT_INFILE" -outfile "$INPUT_OUTFILE"
+/app/gcov2lcov-linux-amd64 -infile "$INPUT_INFILE" -outfile "$INPUT_OUTFILE"


### PR DESCRIPTION
use a pre-compiled gcov2lcov binary instead of running go get.
addresses #5 