### PR TITLE
make sure GOROOT is set (#13)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ runs:
         RELEASE: "https://github.com/jandelgado/gcov2lcov/releases/download/${{inputs.version}}"
         LATEST_RELEASE: "https://github.com/jandelgado/gcov2lcov/releases/latest/download"
     - shell: bash
-      run: set -x && /tmp/gcov2lcov-linux-amd64 -infile "${{ inputs.infile }}" -outfile "${{ inputs.outfile }}"
+      run: 'set -x && GOROOT=$(go env GOROOT) /tmp/gcov2lcov-linux-amd64 -infile "${{ inputs.infile }}" -outfile "${{ inputs.outfile }}"'
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
because the invoked gcov2lcov uses golang API functions that rely on
GOROOT (i.e. build.Import, which calls
https://cs.opensource.google/go/go/+/refs/tags/go1.18.2:src/go/build/build.go;drc=0a1a092c4b56a1d4033372fbd07924dad8cbb50b;l=544)

Up to version v3 of the github setup-go action, the GOROOT variable was
automatically set. But that changed with v3 of the setup-go action, and
that's why we now set GOROOT.