### PR TITLE
Add GitHub token authentication to avoid rate limits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,13 +34,15 @@ runs:
         else
           URL="https://api.github.com/repos/jandelgado/gcov2lcov/releases/tags/${{inputs.version}}"
         fi
+        AUTH_HEADER=""
         if [ -n "${{ inputs.github-token }}" ]; then
           echo "Using authenticated GitHub API request"
-          PACKAGE_URL=$(curl -H "Authorization: Bearer ${{ inputs.github-token }}" "$URL" | jq -r '[ .assets[] | select(.name | test("gcov2lcov.*linux.amd64.tar.gz")) | .browser_download_url ] | first ')
+          AUTH_HEADER="Authorization: Bearer ${{ inputs.github-token }}"
         else
           echo "Using unauthenticated GitHub API request" 
-          PACKAGE_URL=$(curl "$URL" | jq -r '[ .assets[] | select(.name | test("gcov2lcov.*linux.amd64.tar.gz")) | .browser_download_url ] | first ')
         fi
+        
+        PACKAGE_URL=$(curl ${AUTH_HEADER:+-H "$AUTH_HEADER"} "$URL" | jq -r '[ .assets[] | select(.name | test("gcov2lcov.*linux.amd64.tar.gz")) | .browser_download_url ] | first ')
         
         # starting with version v1.1.0 gcov2lcov changed it's artefact naming a bit.
         # we are gentle and support also the old naming convetion

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   working-directory:
     description: "change working directory"
     required: false
+  github-token:
+    description: "GitHub token for API authentication. Defaults to the automatic GitHub token for improved rate limits."
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -30,9 +34,16 @@ runs:
         else
           URL="https://api.github.com/repos/jandelgado/gcov2lcov/releases/tags/${{inputs.version}}"
         fi
+        if [ -n "${{ inputs.github-token }}" ]; then
+          echo "Using authenticated GitHub API request"
+          PACKAGE_URL=$(curl -H "Authorization: Bearer ${{ inputs.github-token }}" "$URL" | jq -r '[ .assets[] | select(.name | test("gcov2lcov.*linux.amd64.tar.gz")) | .browser_download_url ] | first ')
+        else
+          echo "Using unauthenticated GitHub API request" 
+          PACKAGE_URL=$(curl "$URL" | jq -r '[ .assets[] | select(.name | test("gcov2lcov.*linux.amd64.tar.gz")) | .browser_download_url ] | first ')
+        fi
+        
         # starting with version v1.1.0 gcov2lcov changed it's artefact naming a bit.
         # we are gentle and support also the old naming convetion
-        PACKAGE_URL=$(curl "$URL" | jq -r '[ .assets[] | select(.name | test("gcov2lcov.*linux.amd64.tar.gz")) | .browser_download_url ] | first ')
         curl -sLf "$PACKAGE_URL" | tar zxf -
         mv bin/gcov2lcov-linux-amd64 gcov2lcov > /dev/null 2>&1 || true  # before v1.1.0
 


### PR DESCRIPTION
## Summary
- Adds optional `github-token` parameter to authenticate GitHub API requests
- Increases rate limit from 60 requests/hour to 5000 requests/hour
- Maintains full backward compatibility with automatic token defaulting

## Problem
The action fails intermittently when GitHub's unauthenticated API rate limit (60 requests/hour) is exceeded, particularly in busy CI environments with multiple workflows.

## Solution
Added conditional authentication using the GitHub token that's automatically available in workflows. The implementation:
- Defaults to `${{ github.token }}` for zero-configuration improvement
- Falls back gracefully when no token is provided
- Adds minimal logging to indicate authentication status

## Evidence
Testing confirmed the rate limit improvements in [this workflow run](https://github.com/billykern/gcov2lcov-action/actions/runs/16274785945):
- **Unauthenticated**: `x-ratelimit-limit: 60` 
- **Authenticated**: `x-ratelimit-limit: 5000`

The test validates three scenarios:
1. Current upstream behavior (60/hour limit)
2. With authentication using default token (5000/hour limit)
3. Empty token parameter (graceful fallback to 60/hour limit)

## Testing
- Verified backward compatibility with empty/missing token
- Confirmed successful authentication with default token
- Tested explicit token passing

## References
- [GitHub API rate limiting docs](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting)
- [Automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)